### PR TITLE
Fix Paper plugin dependency classpath

### DIFF
--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -5,7 +5,51 @@ api-version: '1.21'
 folia-supported: true
 dependencies:
   server:
+    PlaceholderAPI:
+      load: BEFORE
+      required: true
+      join-classpath: true
     Vault:
+      load: BEFORE
+      required: false
+      join-classpath: true
+    HeadDatabase:
+      load: BEFORE
+      required: false
+      join-classpath: true
+    CraftEngine:
+      load: BEFORE
+      required: false
+      join-classpath: true
+    ItemsAdder:
+      load: BEFORE
+      required: false
+      join-classpath: true
+    Nexo:
+      load: BEFORE
+      required: false
+      join-classpath: true
+    Oraxen:
+      load: BEFORE
+      required: false
+      join-classpath: true
+    MMOItems:
+      load: BEFORE
+      required: false
+      join-classpath: true
+    ExecutableItems:
+      load: BEFORE
+      required: false
+      join-classpath: true
+    ExecutableBlocks:
+      load: BEFORE
+      required: false
+      join-classpath: true
+    Score:
+      load: BEFORE
+      required: false
+      join-classpath: true
+    SimpleItemGenerator:
       load: BEFORE
       required: false
       join-classpath: true


### PR DESCRIPTION
fixes startup crash on Paper caused by missing PlaceholderAPI classpath access in `paper-plugin.yml`

If I use this on the 1.21.11 Folia fork with PAPI support, I get the following error:
```
[01:38:19] [Server thread/ERROR]: Error occurred while enabling DeluxeMenus v1.14.2-DEV-null (Is it up to date?)
java.lang.NoClassDefFoundError: me/clip/placeholderapi/expansion/PlaceholderExpansion
	at java.base/java.lang.ClassLoader.defineClass1(Native Method) ~[?:?]
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:962) ~[?:?]
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:144) ~[?:?]
	at io.papermc.paper.plugin.entrypoint.classloader.PaperSimplePluginClassLoader.findClass(PaperSimplePluginClassLoader.java:110) ~[universe-1.21.11.jar:1.21.11-b94ae2e]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:557) ~[?:?]
	at io.papermc.paper.plugin.entrypoint.classloader.PaperPluginClassLoader.loadClass(PaperPluginClassLoader.java:118) ~[universe-1.21.11.jar:1.21.11-b94ae2e]
	at io.papermc.paper.plugin.entrypoint.classloader.PaperPluginClassLoader.loadClass(PaperPluginClassLoader.java:107) ~[universe-1.21.11.jar:1.21.11-b94ae2e]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490) ~[?:?]
	at DeluxeMenus-1.14.2-DEV-null.jar//com.extendedclip.deluxemenus.DeluxeMenus.onEnable(DeluxeMenus.java:119) ~[?:?]
	at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:279) ~[universe-1.21.11.jar:1.21.11-b94ae2e]
	at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.enablePlugin(PaperPluginInstanceManager.java:207) ~[universe-1.21.11.jar:1.21.11-b94ae2e]
	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.enablePlugin(PaperPluginManagerImpl.java:109) ~[universe-1.21.11.jar:1.21.11-b94ae2e]
	at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:520) ~[universe-1.21.11.jar:1.21.11-b94ae2e]
	at org.bukkit.craftbukkit.CraftServer.enablePlugin(CraftServer.java:645) ~[universe-1.21.11.jar:1.21.11-b94ae2e]
	at org.bukkit.craftbukkit.CraftServer.enablePlugins(CraftServer.java:601) ~[universe-1.21.11.jar:1.21.11-b94ae2e]
	at net.minecraft.server.MinecraftServer.initPostWorld(MinecraftServer.java:628) ~[universe-1.21.11.jar:1.21.11-b94ae2e]
	at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:375) ~[universe-1.21.11.jar:1.21.11-b94ae2e]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1238) ~[universe-1.21.11.jar:1.21.11-b94ae2e]
	at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:391) ~[universe-1.21.11.jar:1.21.11-b94ae2e]
	at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]
Caused by: java.lang.ClassNotFoundException: me.clip.placeholderapi.expansion.PlaceholderExpansion
	at io.papermc.paper.plugin.entrypoint.classloader.PaperPluginClassLoader.loadClass(PaperPluginClassLoader.java:146) ~[universe-1.21.11.jar:1.21.11-b94ae2e]
	at io.papermc.paper.plugin.entrypoint.classloader.PaperPluginClassLoader.loadClass(PaperPluginClassLoader.java:107) ~[universe-1.21.11.jar:1.21.11-b94ae2e]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490) ~[?:?]
	... 20 more
```